### PR TITLE
change vdp memory map for bitmap mode to allow sprites

### DIFF
--- a/vdp_setbitmap.c
+++ b/vdp_setbitmap.c
@@ -5,10 +5,10 @@ int set_bitmap(int sprite_mode) {
 	int unblank = VDP_MODE1_16K | VDP_MODE1_UNBLANK | VDP_MODE1_INT | sprite_mode;
 	VDP_SET_REGISTER(VDP_REG_MODE0, VDP_MODE0_BITMAP);
 	VDP_SET_REGISTER(VDP_REG_MODE1, VDP_MODE1_16K);		// no need to OR in the sprite mode for now
-	VDP_SET_REGISTER(VDP_REG_SIT, 0x06);	gImage = 0x1800;
+	VDP_SET_REGISTER(VDP_REG_SIT, 0x0E);	gImage = 0x3800;
 	VDP_SET_REGISTER(VDP_REG_CT, 0xFF);		gColor = 0x2000;
 	VDP_SET_REGISTER(VDP_REG_PDT, 0x03);	gPattern = 0x0000;
-	VDP_SET_REGISTER(VDP_REG_SAL, 0x36);	gSprite = 0x1B00;	vdpchar(gSprite, 0xd0);
+	VDP_SET_REGISTER(VDP_REG_SAL, 0x76);	gSprite = 0x3B00;	vdpchar(gSprite, 0xd0);
 	VDP_SET_REGISTER(VDP_REG_SDT, 0x03);	gSpritePat = 0x1800;
 	nTextRow = 736;
 	nTextEnd = 767;


### PR DESCRIPTION
I was creating a little bitmap app that also used sprites, and the first two rows of bitmap data were goofed up by my sprite patterns, because gImage and gSpritePat overlapped. Maybe you did this on purpose to keep more VDP memory free?  But this configuration allows sprites and bitmap mode to get along / less astonishment.

Now follows memory map as written in:
  Video Display Processors Programmer's Guide, by Texas Instruments.

http://www.msxblog.es/wp-content/uploads/2009/09/vdpprogrammersguide.pdf

