### PR TITLE
Prevent double-inclusion by wrapping headers in #ifdefs.

### DIFF
--- a/conio.h
+++ b/conio.h
@@ -6,6 +6,9 @@
 // this code maintains its own cursor position and is not compatible with the 
 // vdp_put functions directly.
 
+#ifndef CONIO_H
+#define CONIO_H
+
 #include "vdp.h"
 #include <stdarg.h>
 
@@ -96,3 +99,5 @@ inline int wherex() { return conio_x; }
 
 // return the y position
 inline int wherey() { return conio_y; }
+
+#endif /* CONIO_H */

--- a/files.h
+++ b/files.h
@@ -1,3 +1,6 @@
+#ifndef FILES_H
+#define FILES_H
+
 // DSR interface code for the TI-99/4A by Tursi
 // You can copy this file and use it at will ;)
 
@@ -89,3 +92,5 @@ unsigned char dsrlnk(struct PAB *pab, unsigned int vdp);
 // Inputs: pointer to PAB in VDP
 // Note: no return code. Read it from the PAB yourself. :)
 void dsrlnkraw(unsigned int vdppab);
+
+#endif /* FILES_H */

--- a/grom.h
+++ b/grom.h
@@ -1,6 +1,9 @@
 // GROM code for the TI-99/4A by Tursi
 // You can copy this file and use it at will ;)
 
+#ifndef GROM_H
+#define GROM_H
+
 //*********************
 // default GROM access port addresses (base 0)
 //*********************
@@ -55,3 +58,5 @@ unsigned char GromReadData(unsigned int address, unsigned char port);
 // Note that console GROMs and most cartridges will respond at all ports. The maximum port supported
 // by this library is 15. Assumes that writable GROM is available.
 void GromWriteData(unsigned int address, unsigned char port, unsigned char dat);
+
+#endif /* GROM_H */

--- a/kscan.h
+++ b/kscan.h
@@ -4,6 +4,9 @@
 // KSCAN related addresses
 //*********************
 
+#ifndef KSCAN_H
+#define KSCAN_H
+
 // Address to set the scan mode (see KSCAN_MODE_xxx defines)
 #define KSCAN_MODE	*((volatile unsigned char*)0x8374)
 
@@ -60,3 +63,4 @@ void kscanfast(int mode);
 // returns data in KSCAN_JOYY and KSCAN_JOYX
 void joystfast(int unit);
 
+#endif /* KSCAN_H */

--- a/math.h
+++ b/math.h
@@ -1,8 +1,13 @@
 // Math code for the TI-99/4A
 // Free to use
 
+#ifndef MATH_H
+#define MATH_H
+
 int sqrt(int x);
 
 inline int abs(int x) {
     return x > 0 ? x : (-1 * x);
 }
+
+#endif /* MATH_H */

--- a/player.h
+++ b/player.h
@@ -9,6 +9,9 @@
 // memory and CPU but is otherwise the same.
 //*********************
 
+#ifndef PLAYER_H
+#define PLAYER_H
+
 //*********************
 // Player Data
 //*********************
@@ -43,3 +46,5 @@ void stplay();
 // inputs - pSong - pointer to song data
 // returns - count (which is just the table pointers subtracted and divided)
 unsigned int stcount(const void *pSong);
+
+#endif /* PLAYER_H */

--- a/player30hz.h
+++ b/player30hz.h
@@ -9,6 +9,9 @@
 // memory and CPU but is otherwise the same.
 //*********************
 
+#ifndef PLAYER30HZ_H
+#define PLAYER30HZ_H
+
 //*********************
 // Player Data
 //*********************
@@ -43,3 +46,5 @@ void stplay30();
 // inputs - pSong - pointer to song data
 // returns - count (which is just the table pointers subtracted and divided)
 unsigned int stcount(const void *pSong);
+
+#endif /* PLAYER30HZ_H */

--- a/playersfx.h
+++ b/playersfx.h
@@ -8,6 +8,9 @@
 // want music, use player.h which will use less memory and CPU time.
 //*********************
 
+#ifndef PLAYERSFX_H
+#define PLAYERSFX_H
+
 //*********************
 // Player Data
 //*********************
@@ -56,3 +59,5 @@ void stplaysfx();
 // inputs - pSong - pointer to song data
 // returns - count (which is just the table pointers subtracted and divided)
 unsigned int stcount(const void *pSong);
+
+#endif /* PLAYERSFX_H */

--- a/playersfx30hz.h
+++ b/playersfx30hz.h
@@ -8,6 +8,9 @@
 // If you only want music, use player.h which will use less memory and CPU time.
 //*********************
 
+#ifndef PLAYERSFX30HZ_H
+#define PLAYERSFX30HZ_H
+
 //*********************
 // Player Data
 //*********************
@@ -56,3 +59,5 @@ void stplaysfx30();
 // inputs - pSong - pointer to song data
 // returns - count (which is just the table pointers subtracted and divided)
 unsigned int stcount(const void *pSong);
+
+#endif /* PLAYERSFX30HZ_H */

--- a/puff.h
+++ b/puff.h
@@ -21,6 +21,8 @@
   Mark Adler    madler@alumni.caltech.edu
  */
 
+#ifndef PUFF_H
+#define PUFF_H
 
 /*
  * See puff.c for purpose and usage.
@@ -33,3 +35,5 @@ int puff(unsigned char *dest,          /* pointer to destination pointer */
          unsigned int *destlen,        /* amount of output space */
          const unsigned char *source, /* pointer to source data pointer */
          unsigned int *sourcelen);     /* amount of input available */
+
+#endif /* PUFF_H */

--- a/puff16k.h
+++ b/puff16k.h
@@ -21,6 +21,8 @@
   Mark Adler    madler@alumni.caltech.edu
  */
 
+#ifndef PUFF16K_H
+#define PUFF16K_H
 
 /*
  * See puff.c for purpose and usage.
@@ -38,3 +40,5 @@ int puff16k(unsigned char *dest,          /* pointer to destination pointer */
          unsigned int *destlen,        /* amount of output space */
          const unsigned char *source, /* pointer to source data pointer */
          unsigned int *sourcelen);     /* amount of input available */
+
+#endif /* PUFF16K_H */

--- a/sound.h
+++ b/sound.h
@@ -1,5 +1,8 @@
 // Helpers for direct and console interrupt sound processing
 
+#ifndef SOUND_H
+#define SOUND_H
+
 //*********************
 // direct sound chip access
 //*********************
@@ -47,3 +50,5 @@ inline void START_SOUND()					{	SOUND_CNT = 1;					}
 
 // mute all channels
 inline void MUTE_SOUND()					{ SOUND=TONE1_VOL|0x0f; SOUND=TONE2_VOL|0x0f; SOUND=TONE3_VOL|0x0f; SOUND=NOISE_VOL|0x0f; }
+
+#endif /* SOUND_H */

--- a/string.h
+++ b/string.h
@@ -1,6 +1,9 @@
 // String code for the TI-99/4A by Tursi
 // You can copy this file and use it at will ;)
 
+#ifndef STRING_H
+#define STRING_H
+
 // strlen - returns the length of a zero terminated string
 int strlen(const char *s);
 
@@ -26,3 +29,5 @@ char *int2str(int x);
 // Displays a solid cursor. The only edit key supported is Fctn-S. Stops
 // at maxlen, returned string is zero-terminated. Needs KSCAN, VDP, etc.
 void gets(char *buf, int maxlen);
+
+#endif /* STRING_H */

--- a/system.h
+++ b/system.h
@@ -1,3 +1,6 @@
+#ifndef SYSTEM_H
+#define SYSTEM_H
+
 // Halt function -- stops the program and waits for
 // the user to press QUIT (Fctn-=). Use this if you
 // do not want to simply exit main (which in my startup
@@ -7,3 +10,5 @@ void halt() __attribute__ ((noreturn));
 
 // Exit function -- reboots the console.
 void exit() __attribute__ ((noreturn));
+
+#endif /* SYSTEM_H */

--- a/vdp.h
+++ b/vdp.h
@@ -3,6 +3,10 @@
 // This code and library released into the Public Domain
 // You can copy this file and use it at will ;)
 
+#ifndef VDP_H
+#define VDP_H
+
+
 //*********************
 // VDP access ports
 //*********************
@@ -400,3 +404,5 @@ extern unsigned char gSaveIntCnt;	// console interrupt count byte
 
 // 512 byte lookup table for converting a byte to two ASCII hex characters
 extern const unsigned int byte2hex[256];
+
+#endif /* VDP_H */


### PR DESCRIPTION
Ran into some issues where things were being double included while developing PLATOTerm. Hopefully this will help prevent that from happening. Thanks again for libti99, it is making it possible to port PLATOTerm to the TI-99/4A